### PR TITLE
Mirror of aws aws-sdk-java#1229

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
@@ -394,7 +394,7 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
     }
 
     @Override
-    public <T extends Object> T load(T keyObject, DynamoDBMapperConfig config) {
+    public <T> T load(T keyObject, DynamoDBMapperConfig config) {
         @SuppressWarnings("unchecked")
         Class<T> clazz = (Class<T>) keyObject.getClass();
 
@@ -443,6 +443,10 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
                 toParameters(itemAttributes, clazz, tableName, config));
     }
 
+    private <T extends Object> DynamoDBMapperTableModel<? extends T> getTableModel(Class<T> clazz, DynamoDBMapperConfig config, Map<String, AttributeValue> values) {
+        return getTableModel(getSubType(clazz, values), config);
+    }
+
     /**
      * The one true implementation of marshallIntoObject.
      */
@@ -452,7 +456,7 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         Class<T> clazz = parameters.getModelClass();
         Map<String, AttributeValue> values = untransformAttributes(parameters);
 
-        final DynamoDBMapperTableModel<T> model = getTableModel(clazz, parameters.getMapperConfig());
+        final DynamoDBMapperTableModel<? extends T> model = getTableModel(clazz, parameters.getMapperConfig(), values);
         return model.unconvert(values);
     }
 
@@ -727,6 +731,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
                 }
             }
 
+            if (model.requiresSubTypeAttribute()) {
+                onNonKeyAttribute(model.subTypeAttributeName(), new AttributeValue(model.subTypeAttributeValue()));
+            }
             /*
              * Execute the implementation of the low level request.
              */
@@ -2267,6 +2274,41 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
             }
             return maps;
         }
+    }
+
+
+    /**
+     * A utility method that determines if the given type has subtypes and based on the attributes
+     * from the DB figures out which sub-type should be created. Fallback to base class if not found.
+     *
+     * @param startingType     type that was specified on the load request (ie base class)
+     * @param objectAttributes attributes of the DDB object so we can determine the type
+     *
+     * @return the actual type to create
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> Class<? extends T> getSubType(final Class<T> startingType, final Map<String, AttributeValue> objectAttributes) {
+        DynamoDBSubTyped subTypes = startingType.getAnnotation(DynamoDBSubTyped.class);
+        if (subTypes != null && objectAttributes.containsKey(subTypes.attributeName())) {
+            String type = objectAttributes.get(subTypes.attributeName()).getS();
+            for (DynamoDBSubTyped.SubType subType : subTypes.value()) {
+                if (subType.name().equals(type)) {
+                    try {
+                        return subType.value().asSubclass(startingType);
+                    } catch (ClassCastException e) {
+                        throw new DynamoDBMappingException(
+                                String.format("Invalid @%s(name = \"%s\", value = %s.class), type '%s' is not a subclass of '%s'",
+                                        DynamoDBSubTyped.SubType.class.getSimpleName(),
+                                        subType.name(),
+                                        subType.value().getSimpleName(),
+                                        subType.value().getName(),
+                                        startingType.getName()),
+                                e);
+                    }
+                }
+            }
+        }
+        return startingType;
     }
 
     /**

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTableModel.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTableModel.java
@@ -49,6 +49,7 @@ public final class DynamoDBMapperTableModel<T> implements DynamoDBTypeConverter<
     private final Map<KeyType,DynamoDBMapperFieldModel<T,Object>> keys;
     private final DynamoDBMapperTableModel.Properties<T> properties;
     private final Class<T> targetType;
+    private final boolean requiresSubTypeAttribute;
 
     /**
      * Constructs a new table model for the specified class.
@@ -62,6 +63,9 @@ public final class DynamoDBMapperTableModel<T> implements DynamoDBTypeConverter<
         this.keys = builder.keys();
         this.properties = builder.properties;
         this.targetType = builder.targetType;
+        this.requiresSubTypeAttribute = properties.subTypeAttributeName() != null &&
+                properties.subTypeAttributeValue() != null &&
+                !fields.containsKey(properties.subTypeAttributeName());
     }
 
     /**
@@ -231,6 +235,16 @@ public final class DynamoDBMapperTableModel<T> implements DynamoDBTypeConverter<
         }
         return copy;
     }
+
+    public String subTypeAttributeName() {
+        return properties.subTypeAttributeName();
+    }
+
+    public String subTypeAttributeValue() {
+        return properties.subTypeAttributeValue();
+    }
+
+    public boolean requiresSubTypeAttribute() { return requiresSubTypeAttribute; }
 
     /**
      * {@inheritDoc}
@@ -456,18 +470,34 @@ public final class DynamoDBMapperTableModel<T> implements DynamoDBTypeConverter<
      * The table model properties.
      */
     static interface Properties<T> {
-        public String tableName();
+        String tableName();
+        String subTypeAttributeName();
+        String subTypeAttributeValue();
 
         static final class Immutable<T> implements Properties<T> {
             private final String tableName;
+            private final String subTypeAttributeName;
+            private final String subTypeAttributeValue;
 
             public Immutable(final Properties<T> properties) {
                 this.tableName = properties.tableName();
+                this.subTypeAttributeName = properties.subTypeAttributeName();
+                this.subTypeAttributeValue = properties.subTypeAttributeValue();
             }
 
             @Override
             public String tableName() {
                 return this.tableName;
+            }
+
+            @Override
+            public String subTypeAttributeName() {
+                return subTypeAttributeName;
+            }
+
+            @Override
+            public String subTypeAttributeValue() {
+                return subTypeAttributeValue;
             }
         }
     }

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBSubTyped.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBSubTyped.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016. Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.dynamodbv2.datamodeling;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to describe a classes known sub-types along with a string-identifier
+ * for those types that is persisted to the Dynamo table and allows the sub-type information
+ * to be persisted at save and retrieved at load time.
+ * <p>
+ * This annotation is inherited by subclasses, and can be overridden by them as
+ * well.
+ *
+ * Example usage:
+ * <pre class="brush: java">
+ * &#064;DynamoDBSubTyped({
+ *  &#064;SubType(name = "firstSubType", value = FirstSubType.class),
+ *  &#064;SubType(name = "secondSubType", value = SecondSubType.class)
+ * })
+ * class BaseClass { }
+ *
+ * class FirstSubType extends BaseClass { }
+ * class SecondSubType extends BaseClass { }
+ * </pre>
+ * <p>
+ * By default the type name is stored in a String field in Dynamo called "_type"; this can be customized by providing the "attributeName"
+ * property to the &#064;DynamoDBSubTyped annotation. This attribute can refer to an attribute already on the object if it doesn't exist
+ * as a property of the object it will be created. It must be of type java.lang.String.
+ */
+
+@DynamoDB
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface DynamoDBSubTyped {
+
+    SubType[] value();
+
+    String attributeName() default "_type";
+
+    @interface SubType {
+
+        Class<?> value();
+
+        String name();
+    }
+}

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardAnnotationMaps.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardAnnotationMaps.java
@@ -21,7 +21,6 @@ import static com.amazonaws.services.dynamodbv2.model.KeyType.RANGE;
 import com.amazonaws.annotation.SdkInternalApi;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperFieldModel.DynamoDBAttributeType;
 import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.util.StringUtils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
@@ -227,6 +226,28 @@ final class StandardAnnotationMaps {
             final DynamoDBTable annotation = actualOf(DynamoDBTable.class);
             if (annotation != null && !annotation.tableName().isEmpty()) {
                 return annotation.tableName();
+            }
+            return null;
+        }
+
+        @Override
+        public String subTypeAttributeName() {
+            final DynamoDBSubTyped annotation = actualOf(DynamoDBSubTyped.class);
+            if (annotation != null && !annotation.attributeName().isEmpty()) {
+                return annotation.attributeName();
+            }
+            return null;
+        }
+
+        @Override
+        public String subTypeAttributeValue() {
+            final DynamoDBSubTyped annotation = actualOf(DynamoDBSubTyped.class);
+            if (annotation != null) {
+                for (DynamoDBSubTyped.SubType subType : annotation.value()) {
+                    if (subType.value().equals(targetType())) {
+                        return subType.name();
+                    }
+                }
             }
             return null;
         }


### PR DESCRIPTION
Mirror of aws aws-sdk-java#1229
In response to issue #832, this introduces a new `@DynamoDBSubTyped` annotation to describe known sub-types of a class along with a string-identifier for those types that is persisted to the Dynamo table and allows the sub-type information to be persisted at save and retrieved at load time.

Example usage:

```java
@DynamoDBSubTyped({
	@SubType(name = "firstSubType", value = FirstSubType.class),
	@SubType(name = "secondSubType", value = SecondSubType.class)
})
class BaseClass { }

class FirstSubType extends BaseClass { }
class SecondSubType extends BaseClass { }
```
By default the type name is stored in a String field in Dynamo called "_type"; this can be customized by providing the "attributeName" property to the `@DynamoDBSubTyped` annotation. This attribute can refer to an property already on the object or if it doesn't exist as a property of the object it will be created in the dynamo db table. It must be of type `java.lang.String`.

The above example allows the following:

```java
mapper.save(firstSubType);
mapper.save(secondSubType);

FirstSubType loadedFirstSubType = (FirstSubType) mapper.load(BaseClass.class, /*some id for firstSubType*/);
```

Also works with when scanning/querying:

```java
List<BaseClass> objects = mapper.scan(BaseClass.class);
objects.forEach(o -> System.out.println(o.getClass())); 
/* prints FirstSubType.class, SecondSubType.class */
```
