### PR TITLE
Mirror of aws aws-sdk-java#1125

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWSCredentialsProviderChain.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWSCredentialsProviderChain.java
@@ -131,9 +131,35 @@ public class AWSCredentialsProviderChain implements AWSCredentialsProvider {
         throw new SdkClientException("Unable to load AWS credentials from any provider in the chain");
     }
 
+    /**
+     * Forces this credentials provider to refresh the credentials of all
+     * credential providers in its chain.
+     *
+     * If configured to reuse the last successful credential provider, the
+     * cache of the last successful credential provider will be retained.
+     */
     public void refresh() {
+        refresh(false);
+    }
+
+    /**
+     * Forces this credentials provider to refresh the credentials of all
+     * credential providers in its chain.
+     *
+     * If configured to reuse the last successful credential provider, the
+     * cache of the last successful credential provider may be cleared by
+     * providing the resetLastUsedProviderCache flag.
+     *
+     * @param resetLastUsedProviderCache
+     *            Whether or not to clear the last successful credential
+     *            provider; a true value will clear it.
+     */
+    public void refresh(boolean resetLastUsedProviderCache) {
         for (AWSCredentialsProvider provider : credentialsProviders) {
             provider.refresh();
+        }
+        if (resetLastUsedProviderCache) {
+            lastUsedProvider = null;
         }
     }
 }

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AWSCredentialsProviderChainTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AWSCredentialsProviderChainTest.java
@@ -81,6 +81,29 @@ public class AWSCredentialsProviderChainTest {
         assertEquals(2, provider2.getCredentialsCallCount);
     }
 
+    /**
+     * Tests that after refreshing the chain, the last used provider will not
+     * be the only provider used.
+     */
+    @Test
+    public void testRefreshClearsLastProvider() throws Exception {
+        MockCredentialsProvider provider1 = new MockCredentialsProvider();
+        provider1.throwException = true;
+        MockCredentialsProvider provider2 = new MockCredentialsProvider();
+        AWSCredentialsProviderChain chain = new AWSCredentialsProviderChain(provider1, provider2);
+
+        assertEquals(0, provider1.getCredentialsCallCount);
+        assertEquals(0, provider2.getCredentialsCallCount);
+
+        chain.getCredentials();
+        assertEquals(1, provider1.getCredentialsCallCount);
+        assertEquals(1, provider2.getCredentialsCallCount);
+
+        chain.refresh(true);
+        chain.getCredentials();
+        assertEquals(2, provider1.getCredentialsCallCount);
+        assertEquals(2, provider2.getCredentialsCallCount);
+    }
 
     private static final class MockCredentialsProvider extends StaticCredentialsProvider {
         public int getCredentialsCallCount = 0;


### PR DESCRIPTION
Mirror of aws aws-sdk-java#1125
Currently `AWSCredentialsProviderChain`'s cache of the last used credential provider is maintained across `refresh()` invocations in the provider chain.  This means that after you've accessed the credentials once, `refresh()` effectively only refreshes the credential provider that was previously accessed; you can never switch to one earlier in the chain via a refresh.

This PR clears the cached last provider in a refresh.
